### PR TITLE
Use Symbols instead of classes for distinguishing match types

### DIFF
--- a/lib/pampy.js
+++ b/lib/pampy.js
@@ -1,19 +1,12 @@
 "use strict";
 
-class PadValueType {}
-class UnderscoreType {}
-class StringType {}
-class NumberType {}
-class HeadType {}
-class TailType {}
-
-const PAD_VALUE = new PadValueType();
-const _ = new UnderscoreType();
+const PAD_VALUE = Symbol('PadValueType');
+const _ = Symbol('UnderscoreType');
 const ANY = _;
-const STRING = new StringType();
-const NUMBER = new NumberType();
-const HEAD = new HeadType();
-const TAIL = new TailType();
+const STRING = Symbol('StringType');
+const NUMBER = Symbol('NumberType');
+const HEAD = Symbol('HeadType');
+const TAIL = Symbol('TailType');
 const REST = TAIL;
 
 


### PR DESCRIPTION
Since you already use `let` and don't transpile, this won't result in backwards-incompatibility for browsers that don't support Symbols.