### PR TITLE
Require pairs to be passed as arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ match(pet, {_: {age: _}}, (a, b) => [a, b]);          // => ['details', 3]
 ```
 Admittedly using `_` as key is a bit of a trick, but it works for most situations.
 
+## You can pass [pattern, action] array pairs to matchPairs for better Prettier formatting!
+
+```javascript
+function fib(n) {
+    return matchPairs(
+      n,
+      [0, 0],
+      [1, 1],
+      [2, 1],
+      [3, 2],
+      [4, 3],
+      [_, x => fib(x - 1) + fib(x - 2)]
+    )
+  }
+```
+
 ## All the things you can match
 
 | Pattern Example | What it means | Matched Example |  Arguments Passed to function | NOT Matched Example |

--- a/lib/pampy.js
+++ b/lib/pampy.js
@@ -188,6 +188,26 @@ function onlyPadValuesFollow(pairs, i) {
     return true;
 }
 
+
+function matchPairs(x, ...pairs) {
+  if (!pairs.every(p => p.length && p.length === 2)) {
+    throw new MatchError(
+      'Even number of pattern-action pairs. Every pattern should have an action.'
+    )
+  }
+
+  for (let i = 0; i < pairs.length; i++) {
+    let [patt, action] = pairs[i]
+
+    let [matched, extracted] = matchValue(patt, x)
+    if (matched) {
+      return run(action, extracted)
+    }
+  }
+  throw new MatchError(`No _ provided, case ${x} not handled.`)
+}
+
+
 function match(x) {
     const args = [...arguments].slice(1);
     if (args.length % 2 !== 0) {
@@ -196,15 +216,7 @@ function match(x) {
 
     let pairs = pairwise(args);
 
-    for (let i = 0; i < pairs.length; i++) {
-        let [patt, action] = pairs[i];
-
-        let [matched, extracted] = matchValue(patt, x);
-        if (matched) {
-            return run(action, extracted);
-        }
-    }
-    throw new MatchError(`No _ provided, case ${x} not handled.`);
+    return matchPairs(x, ...pairs)
 }
 
 function matchAll(rows) {
@@ -242,6 +254,7 @@ module.exports = {
     matchDict,
     match,
     matchAll,
+    matchPairs,
     zipLongest,
     PAD_VALUE,
     STRING,

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,7 +3,7 @@
 let assert = require('chai').assert;
 let lodash = require('lodash');
 let fs = require('fs');
-let {matchArray, matchValue, matchDict, zipLongest, match, matchAll, _, HEAD, TAIL, REST,} = require('../lib/pampy');
+let {matchArray, matchValue, matchDict, zipLongest, match, matchAll, matchPairs, _, HEAD, TAIL, REST,} = require('../lib/pampy');
 let {PAD_VALUE, STRING, NUMBER, ANY, MatchError} = require('../lib/pampy');
 
 
@@ -62,6 +62,18 @@ describe('matchDict', () => {
         assert.deepEqual(matchDict({a: STRING, _: _}, {a: "1", b: 2}), [true, ["1", 'b', 2]]);
     });
 });
+
+describe('matchPairs', () => {
+    it('accepts [pattern, action] pairs using arrays', () => {
+      function fib(n) {
+        return matchPairs(n, [1, 1], [2, 1], [_, x => fib(x - 1) + fib(x - 2)])
+      }
+
+      assert.equal(fib(2), 1)
+      assert.equal(fib(7), 13)
+    })
+})
+
 describe('match', () => {
     it('bad args num', () => {
         assert.throws(() => match(3, 2), MatchError);


### PR DESCRIPTION
Hey there!

I just recently looked for a decent way of doing pattern matching in JS and it seems I finally find one, this library looks really promising!

The only problem I have is that due to (pattern, action) pairs are not grouped anyhow, using prettier messes things up:
```js
function fib(n) {
    return match(
      n,
      0,
      0,
      1,
      1,
      2,
      1,
      3,
      2,
      4,
      3,
      _,
      x => fib(x - 1) + fib(x - 2)
    )
  }
```

If we wrap each pair in an array it looks way better:
```js
function fib(n) {
    return match(
      n,
      [0, 0],
      [1, 1],
      [2, 1],
      [3, 2],
      [4, 3],
      [_, x => fib(x - 1) + fib(x - 2)]
    )
  }
```

Have you considered something like this? I know the downside is that we add some unnecessary arrays, but it's probably negligible. What we get is:
- each pattern and action logically grouped together
- great prettier formatting
- it could probably help to get rid of the pairwise call: https://github.com/santinic/pampy.js/blob/master/lib/pampy.js#L197
- much easier to type in TypeScript

Let me know what you think!
