### PR TITLE
Fix(README): fix syntax error in fibonacci example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ function lisp(exp) {
         Array,              (l) => l.map(lisp),
         _,                  (x) => x
     );
-
+}
 let plus = (a, b) => a + b;
 let minus = (a, b) => a - b;
 let reduce = (f, l) => l.reduce(f);


### PR DESCRIPTION
The function in the original lisp calculator example had a syntax error (missing terminating brace). Nevermind the commit message.