### PR TITLE
Distribute a browser-compatible version of pampy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,7 @@ typings/
 # next.js build output
 .next
 
+# browser-compatible version
+dist/
+
 .idea/

--- a/README.md
+++ b/README.md
@@ -159,3 +159,12 @@ function fib(n) {
 
 ## How to install
 ```npm install pampy```
+
+## Browser usage
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/pampy/dist/pampy.min.js"></script>
+<script>
+  pampy.match(input, pattern, action);
+</script>
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "/lib",
+    "/dist",
     "LICENSE",
     "README.md"
   ],
@@ -25,12 +26,14 @@
     "coveralls": "^3.0.2",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^13.1.0"
+    "nyc": "^13.1.0",
+    "lyo": "1.2.0"
   },
   "scripts": {
     "test": "mocha tests",
     "coverage": "node_modules/nyc/bin/nyc.js report npm test",
-    "coveralls": "node_modules/nyc/bin/nyc.js report --reporter=text-lcov npm test | coveralls"
+    "coveralls": "node_modules/nyc/bin/nyc.js report --reporter=text-lcov npm test | coveralls",
+    "prepublishOnly": "lyo"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
People might want to use pampy directly in a browser, which means they need a version of pampy with a good cross-browser compatibility (support of old javascript versions).

I've added [Lyo](https://github.com/bokub/lyo) as a pre-publish task, so everytime you run `npm publish`, a browser-compatible bundle of pampy will be created in a `/dist` folder, and will be published to the npm registry.

You can test what it does by running `npm run prepublishOnly`.

I've added the dist folder to your `.gitignore`, but it's up to you to commit it if you want.

[Here](https://pastebin.com/raw/hTQTMz8e) is a preview of the bundle, and [here](https://jsfiddle.net/bokub/Lpk4wa20/) is a simple jsFiddle to prove that it works well.

I've also added some lines of documentation in your `README` so people can use the CDN version of the bundle provided by jsDelivr.