### PR TITLE
Support objects as actions

### DIFF
--- a/lib/pampy.js
+++ b/lib/pampy.js
@@ -27,6 +27,9 @@ function run(action, x) {
     else if (action instanceof Function) {
         return action.apply(null, x);
     }
+    else if (isObject(action)) {
+        return action;
+    }
     else {
         throw new MatchError(`Unsupported action type ${typeof(action)} of action ${action}.`)
     }


### PR DESCRIPTION
I wanted to do things like:
```
match(x
  1, {x: 1},
  _, {x: "some"}
)
```

I don't know if that wasn't possible by design?